### PR TITLE
Fix bibliography in paper

### DIFF
--- a/paper/references.bib
+++ b/paper/references.bib
@@ -15,7 +15,7 @@
   pages={305--325},
   year={1946},
   publisher={JSTOR},
-  doi={https://doi.org/10.2307/2332195}
+  doi={10.2307/2332195}
 }
 
 @misc{baudin2015pydoe,
@@ -57,5 +57,5 @@
   pages={10--20},
   year={2007},
   publisher={IEEE},
-  doi={https://doi.org/10.1109/MCSE.2007.58}
+  doi={10.1109/MCSE.2007.58}
 }


### PR DESCRIPTION
The DOI field should be a bare DOI, not protocol prefix.  

Signed-off-by: Bruce Wilson <usethedata@gmail.com>